### PR TITLE
Migrate to guzzlehttp/psr7 v2 compat (PHP 8.4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/yaml": "^3.2|^4.3|^5.0",
         "nesbot/carbon": "^2.0",
         "illuminate/collections": "^10.0 || ^11.0 || ^12.0",
-        "guzzlehttp/psr7": "^1.7.0",
+        "guzzlehttp/psr7": "^1.7.0 || ^2.0",
         "psr/cache": "^1.0",
         "league/flysystem-memory": "^1.0",
         "cache/filesystem-adapter": "^1.0",

--- a/src/DataStore/DefaultDataStore.php
+++ b/src/DataStore/DefaultDataStore.php
@@ -18,8 +18,7 @@
 namespace Okta\DataStore;
 
 use Cache\Adapter\Common\CacheItem;
-use function GuzzleHttp\Psr7\build_query;
-use function GuzzleHttp\Psr7\parse_query;
+use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\HttpClient;
@@ -383,7 +382,7 @@ class DefaultDataStore
      */
     private function appendQueryValues($currentQuery, $queryDictionary)
     {
-        $currentQueryParts = parse_query($currentQuery);
+        $currentQueryParts = Query::parse($currentQuery);
 
         if ($currentQuery == '') {
             $result = [];
@@ -399,7 +398,7 @@ class DefaultDataStore
         }
 
         $result = array_replace_recursive($currentQueryParts, $result);
-        return build_query($result);
+        return Query::build($result);
     }
 
     /**


### PR DESCRIPTION
Replaces removed procedural functions parse_query() and build_query() with their static method equivalents Query::parse() and Query::build(), which exist in both psr7 ^1.7 and ^2.x. Relaxes the constraint to ^1.7.0 || ^2.0 so consumers (e.g. aws-sdk-php on ^2.4.5) can resolve without conflict.